### PR TITLE
Add scheduler and e-prescription contracts

### DIFF
--- a/contracts/appointment-scheduler.clar
+++ b/contracts/appointment-scheduler.clar
@@ -1,0 +1,211 @@
+;; appointment-scheduler
+;; Time-slot booking and provider availability
+;; No cross-contract calls or trait usage
+
+(define-constant ERR-NOT-FOUND u500)
+(define-constant ERR-NOT-AUTHORIZED u501)
+(define-constant ERR-INVALID u502)
+(define-constant ERR-CLOSED u503)
+(define-constant ERR-FULL u504)
+
+(define-data-var next-provider-id uint u1)
+(define-data-var next-slot-id uint u1)
+(define-data-var next-appointment-id uint u1)
+
+;; providers: id -> { owner, name, specialty, active }
+(define-map providers
+  (tuple (provider-id uint))
+  (tuple (owner principal)
+         (name (string-ascii 64))
+         (specialty (string-ascii 32))
+         (active bool)))
+
+;; slots: id -> { provider-id, day, start-min, end-min, capacity, booked, active }
+(define-map slots
+  (tuple (slot-id uint))
+  (tuple (provider-id uint)
+         (day uint)
+         (start-min uint)
+         (end-min uint)
+         (capacity uint)
+         (booked uint)
+         (active bool)))
+
+;; appointments: id -> { patient, slot-id, provider-id, canceled, notes }
+(define-map appointments
+  (tuple (appointment-id uint))
+  (tuple (patient principal)
+         (slot-id uint)
+         (provider-id uint)
+         (canceled bool)
+         (notes (string-ascii 64))))
+
+;; ============ helpers ============
+
+(define-read-only (str-non-empty (s (string-ascii 128)))
+  (ok (> (len s) u0)))
+
+(define-read-only (slot-open? (slot-id uint))
+  (match (map-get? slots { slot-id: slot-id }) s
+    (ok (and (get active s) (< (get booked s) (get capacity s))))
+    (ok false)))
+
+(define-read-only (owns-provider? (provider-id uint) (who principal))
+  (match (map-get? providers { provider-id: provider-id }) p
+    (ok (is-eq (get owner p) who))
+    (ok false)))
+
+;; ============ public api ============
+
+(define-public (register-provider (name (string-ascii 64)) (specialty (string-ascii 32)))
+  (begin
+    (if (or (not (unwrap! (str-non-empty name) (err ERR-INVALID)))
+            (not (unwrap! (str-non-empty specialty) (err ERR-INVALID))))
+        (err ERR-INVALID)
+        (let ((id (var-get next-provider-id)))
+          (var-set next-provider-id (+ id u1))
+          (map-insert providers { provider-id: id }
+            { owner: tx-sender, name: name, specialty: specialty, active: true })
+          (ok id)))))
+
+(define-public (deactivate-provider (provider-id uint))
+  (match (map-get? providers { provider-id: provider-id }) p
+    (if (is-eq (get owner p) tx-sender)
+        (begin
+          (map-set providers { provider-id: provider-id }
+            { owner: (get owner p),
+              name: (get name p),
+              specialty: (get specialty p),
+              active: false })
+          (ok true))
+        (err ERR-NOT-AUTHORIZED))
+    (err ERR-NOT-FOUND)))
+
+(define-public (open-slot (provider-id uint) (day uint) (start-min uint) (end-min uint) (capacity uint))
+  (match (map-get? providers { provider-id: provider-id }) p
+    (let ((owner (get owner p)) (active (get active p)))
+      (if (not (is-eq owner tx-sender))
+          (err ERR-NOT-AUTHORIZED)
+          (if (or (not active) (or (>= start-min end-min) (is-eq capacity u0)))
+              (err ERR-INVALID)
+              (let ((id (var-get next-slot-id)))
+                (var-set next-slot-id (+ id u1))
+                (map-insert slots { slot-id: id }
+                  { provider-id: provider-id,
+                    day: day,
+                    start-min: start-min,
+                    end-min: end-min,
+                    capacity: capacity,
+                    booked: u0,
+                    active: true })
+                (ok id)))))
+    (err ERR-NOT-FOUND)))
+
+(define-public (close-slot (slot-id uint))
+  (match (map-get? slots { slot-id: slot-id }) s
+    (let ((pid (get provider-id s)))
+      (if (not (unwrap! (owns-provider? pid tx-sender) (err ERR-NOT-AUTHORIZED)))
+          (err ERR-NOT-AUTHORIZED)
+          (begin
+            (map-set slots { slot-id: slot-id }
+              { provider-id: pid,
+                day: (get day s),
+                start-min: (get start-min s),
+                end-min: (get end-min s),
+                capacity: (get capacity s),
+                booked: (get booked s),
+                active: false })
+            (ok true))))
+    (err ERR-NOT-FOUND)))
+
+(define-public (reopen-slot (slot-id uint))
+  (match (map-get? slots { slot-id: slot-id }) s
+    (let ((pid (get provider-id s)))
+      (if (not (unwrap! (owns-provider? pid tx-sender) (err ERR-NOT-AUTHORIZED)))
+          (err ERR-NOT-AUTHORIZED)
+          (begin
+            (map-set slots { slot-id: slot-id }
+              { provider-id: pid,
+                day: (get day s),
+                start-min: (get start-min s),
+                end-min: (get end-min s),
+                capacity: (get capacity s),
+                booked: (get booked s),
+                active: true })
+            (ok true))))
+    (err ERR-NOT-FOUND)))
+
+(define-public (book (slot-id uint) (notes (string-ascii 64)))
+  (match (map-get? slots { slot-id: slot-id }) s
+    (begin
+      (if (not (get active s))
+          (err ERR-CLOSED)
+          (if (>= (get booked s) (get capacity s))
+              (err ERR-FULL)
+              (let ((aid (var-get next-appointment-id)))
+                (var-set next-appointment-id (+ aid u1))
+                (map-insert appointments { appointment-id: aid }
+                  { patient: tx-sender,
+                    slot-id: slot-id,
+                    provider-id: (get provider-id s),
+                    canceled: false,
+                    notes: notes })
+                (map-set slots { slot-id: slot-id }
+                  { provider-id: (get provider-id s),
+                    day: (get day s),
+                    start-min: (get start-min s),
+                    end-min: (get end-min s),
+                    capacity: (get capacity s),
+                    booked: (+ (get booked s) u1),
+                    active: (get active s) })
+                (ok aid)))))
+    (err ERR-NOT-FOUND)))
+
+(define-public (cancel-appointment (appointment-id uint))
+  (match (map-get? appointments { appointment-id: appointment-id }) a
+    (if (not (is-eq (get patient a) tx-sender))
+        (err ERR-NOT-AUTHORIZED)
+        (if (get canceled a)
+            (ok false)
+            (begin
+              (map-set appointments { appointment-id: appointment-id }
+                { patient: (get patient a),
+                  slot-id: (get slot-id a),
+                  provider-id: (get provider-id a),
+                  canceled: true,
+                  notes: (get notes a) })
+              (match (map-get? slots { slot-id: (get slot-id a) }) s
+                (let ((b (get booked s)))
+                  (map-set slots { slot-id: (get slot-id a) }
+                    { provider-id: (get provider-id s),
+                      day: (get day s),
+                      start-min: (get start-min s),
+                      end-min: (get end-min s),
+                      capacity: (get capacity s),
+                      booked: (if (> b u0) (- b u1) u0),
+                      active: (get active s) })
+                  (ok true))
+                (err ERR-NOT-FOUND)))))
+    (err ERR-NOT-FOUND)))
+
+;; ============ read-only ============
+
+(define-read-only (get-provider (provider-id uint))
+  (match (map-get? providers { provider-id: provider-id }) p
+    (ok p)
+    (err ERR-NOT-FOUND)))
+
+(define-read-only (get-slot (slot-id uint))
+  (match (map-get? slots { slot-id: slot-id }) s
+    (ok s)
+    (err ERR-NOT-FOUND)))
+
+(define-read-only (get-appointment (appointment-id uint))
+  (match (map-get? appointments { appointment-id: appointment-id }) a
+    (ok a)
+    (err ERR-NOT-FOUND)))
+
+(define-read-only (slot-availability (slot-id uint))
+  (match (map-get? slots { slot-id: slot-id }) s
+    (ok (if (> (get capacity s) (get booked s)) (- (get capacity s) (get booked s)) u0))
+    (err ERR-NOT-FOUND)))

--- a/contracts/e-prescription-service.clar
+++ b/contracts/e-prescription-service.clar
@@ -1,0 +1,127 @@
+;; e-prescription-service
+;; Prescription generation and pharmacy integration (simplified)
+;; No cross-contract calls or trait usage
+
+(define-constant ERR-NOT-FOUND u600)
+(define-constant ERR-NOT-AUTHORIZED u601)
+(define-constant ERR-INVALID u602)
+(define-constant ERR-CANCELED u603)
+(define-constant ERR-NO-REFILLS u604)
+
+(define-data-var next-rx-id uint u1)
+
+;; prescriptions: rx-id -> { prescriber, patient, drug, dosage, quantity, refills, issued, canceled, filled-count }
+(define-map prescriptions
+  (tuple (rx-id uint))
+  (tuple (prescriber principal)
+         (patient principal)
+         (drug (string-ascii 64))
+         (dosage (string-ascii 32))
+         (quantity uint)
+         (refills uint)
+         (issued bool)
+         (canceled bool)
+         (filled-count uint)))
+
+;; fill log: (rx-id, index) -> { pharmacy, quantity }
+(define-map fills
+  (tuple (rx-id uint) (index uint))
+  (tuple (pharmacy principal)
+         (quantity uint)))
+
+;; ===== helpers =====
+
+(define-read-only (str-non-empty (s (string-ascii 128)))
+  (ok (> (len s) u0)))
+
+(define-read-only (max-fills (refills uint))
+  (ok (+ refills u1)))
+
+;; ===== public api =====
+
+(define-public (issue (patient principal) (drug (string-ascii 64)) (dosage (string-ascii 32)) (quantity uint) (refills uint))
+  (begin
+    (if (or (not (unwrap! (str-non-empty drug) (err ERR-INVALID)))
+            (not (unwrap! (str-non-empty dosage) (err ERR-INVALID)))
+            (is-eq quantity u0))
+        (err ERR-INVALID)
+        (let ((id (var-get next-rx-id)))
+          (var-set next-rx-id (+ id u1))
+          (map-insert prescriptions { rx-id: id }
+            { prescriber: tx-sender,
+              patient: patient,
+              drug: drug,
+              dosage: dosage,
+              quantity: quantity,
+              refills: refills,
+              issued: true,
+              canceled: false,
+              filled-count: u0 })
+          (ok id)))))
+
+(define-public (cancel (rx-id uint))
+  (match (map-get? prescriptions { rx-id: rx-id }) rx
+    (if (not (is-eq (get prescriber rx) tx-sender))
+        (err ERR-NOT-AUTHORIZED)
+        (if (get canceled rx)
+            (ok false)
+            (begin
+              (map-set prescriptions { rx-id: rx-id }
+                { prescriber: (get prescriber rx),
+                  patient: (get patient rx),
+                  drug: (get drug rx),
+                  dosage: (get dosage rx),
+                  quantity: (get quantity rx),
+                  refills: (get refills rx),
+                  issued: (get issued rx),
+                  canceled: true,
+                  filled-count: (get filled-count rx) })
+              (ok true))))
+    (err ERR-NOT-FOUND)))
+
+(define-public (fill (rx-id uint) (qty uint))
+  (match (map-get? prescriptions { rx-id: rx-id }) rx
+    (let ((canceled (get canceled rx))
+          (count (get filled-count rx))
+          (max (unwrap! (max-fills (get refills rx)) (err ERR-INVALID)))
+          (base (get quantity rx)))
+      (if canceled
+          (err ERR-CANCELED)
+          (if (or (is-eq qty u0) (not (is-eq qty base)))
+              (err ERR-INVALID)
+              (if (>= count max)
+                  (err ERR-NO-REFILLS)
+                  (let ((next (+ count u1)))
+                    (map-insert fills { rx-id: rx-id, index: next }
+                      { pharmacy: tx-sender, quantity: qty })
+                    (map-set prescriptions { rx-id: rx-id }
+                      { prescriber: (get prescriber rx),
+                        patient: (get patient rx),
+                        drug: (get drug rx),
+                        dosage: (get dosage rx),
+                        quantity: base,
+                        refills: (get refills rx),
+                        issued: (get issued rx),
+                        canceled: false,
+                        filled-count: next })
+                    (ok next))))))
+    (err ERR-NOT-FOUND)))
+
+;; ===== read-only =====
+
+(define-read-only (get-rx (rx-id uint))
+  (match (map-get? prescriptions { rx-id: rx-id }) rx
+    (ok rx)
+    (err ERR-NOT-FOUND)))
+
+(define-read-only (get-fill (rx-id uint) (index uint))
+  (match (map-get? fills { rx-id: rx-id, index: index }) f
+    (ok f)
+    (err ERR-NOT-FOUND)))
+
+(define-read-only (remaining-fills (rx-id uint))
+  (match (map-get? prescriptions { rx-id: rx-id }) rx
+    (let ((max (unwrap! (max-fills (get refills rx)) (err ERR-INVALID)))
+          (count (get filled-count rx)))
+      (ok (if (> max count) (- max count) u0)))
+    (err ERR-NOT-FOUND)))


### PR DESCRIPTION
# PR: Telemedicine contracts

Summary

Introduce two Clarity contracts to support a basic telemedicine flow:
- appointment-scheduler: provider availability, slot creation, booking, and cancellation
- e-prescription-service: issue, cancel, and fill prescriptions with refill limits

Changes

- contracts/appointment-scheduler.clar
  - Providers registry (owner, name, specialty, active)
  - Slots (day, start/end, capacity, booked, active)
  - Appointments (patient, slot, canceled flag, notes)
  - Actions: register-provider, deactivate-provider, open-slot, close-slot, reopen-slot, book, cancel-appointment
  - Read-only: get-provider, get-slot, get-appointment, slot-availability

- contracts/e-prescription-service.clar
  - Prescriptions (prescriber, patient, drug, dosage, quantity, refills, issued, canceled, filled-count)
  - Fill log per prescription
  - Actions: issue, cancel, fill
  - Read-only: get-rx, get-fill, remaining-fills

Validation

- clarinet check
  Contracts compile successfully (warnings only).